### PR TITLE
issue: Add gas snapshot

### DIFF
--- a/snapshots/CLLimitOrderHookTest.json
+++ b/snapshots/CLLimitOrderHookTest.json
@@ -1,3 +1,4 @@
 {
-  "CLLimitOrder_afterSwap_fillEpoch": "149591902"
+  "CLLimitOrder_afterSwap_fillEpoch": "149591902",
+  "CLLimitOrder_fillEpoch_single": "321269"
 }

--- a/snapshots/CLLimitOrderHookTest.json
+++ b/snapshots/CLLimitOrderHookTest.json
@@ -1,0 +1,3 @@
+{
+  "CLLimitOrder_afterSwap_fillEpoch": "149591902"
+}

--- a/test/pool-cl/CLLimitOrder.t.sol
+++ b/test/pool-cl/CLLimitOrder.t.sol
@@ -256,6 +256,7 @@ contract CLLimitOrderHookTest is Test, Deployers, DeployPermit2 {
             }),
             block.timestamp
         );
+        vm.snapshotGasLastCall("CLLimitOrder_afterSwap_fillEpoch");
 
         assertEq(limitOrder.getTickLowerLast(id), 887220);
         (, int24 tick,,) = poolManager.getSlot0(id);

--- a/test/pool-cl/CLLimitOrder.t.sol
+++ b/test/pool-cl/CLLimitOrder.t.sol
@@ -240,7 +240,35 @@ contract CLLimitOrderHookTest is Test, Deployers, DeployPermit2 {
         assertEq(abi.decode(entries[1].data, (uint256)), 2995);
     }
 
+    function testSwapAcrossRange_single_order() public {
+        (, int24 tickBefore,,) = poolManager.getSlot0(id);
+        assertEq(tickBefore, 0);
+        int24 tickLower = 0;
+        bool zeroForOne = true;
+        uint128 liquidity = 1000000;
+        limitOrder.place(key, tickLower, zeroForOne, liquidity);
+
+        swapRouter.exactInputSingle(
+            ICLRouterBase.CLSwapExactInputSingleParams({
+                poolKey: key,
+                zeroForOne: false,
+                amountIn: 5e16,
+                amountOutMinimum: 0,
+                hookData: ZERO_BYTES
+            }),
+            block.timestamp
+        );
+        vm.snapshotGasLastCall("CLLimitOrder_fillEpoch_single");
+
+        assertEq(limitOrder.getTickLowerLast(id), 60);
+        (, int24 tick,,) = poolManager.getSlot0(id);
+        assertEq(tick, 99);
+
+    }
+
     function testSwapAcrossRange() public {
+        (, int24 tickBefore,,) = poolManager.getSlot0(id);
+        assertEq(tickBefore, 0);
         int24 tickLower = 0;
         bool zeroForOne = true;
         uint128 liquidity = 1000000;


### PR DESCRIPTION
Now gas cost of CLLimitOrder_afterSwap_fillEpoch is 149591902 which exceed block gas limit